### PR TITLE
Fixed bug when multiple headers have the same name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name":"ForceCORS",
     "author":"Chris Deely",
-    "version":"1.1",
+    "version":"1.2",
     "description":"Allows forcing Cross-Origin Resource Sharing headers on any desired URL; helpful when accessing remote services from a local host.",
     "homepage_url":"https://github.com/chrisdeely/ForceCORS",
     "icons": { 


### PR DESCRIPTION
I encounter the case where servers send me the same header multiple time leading to problems with the extension (ForceCors just updating the first header entry, not the next ones).

[From RFC](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)
> Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]. It MUST be possible to combine the multiple header fields into one "field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field-value to the first, each separated by a comma. The order in which header fields with the same field-name are received is therefore significant to the interpretation of the combined field value, and thus a proxy MUST NOT change the order of these field values when a message is forwarded.

This pull request merge (or erase) the headers before replacing them by our custom list to avoid the previously discussed problem.